### PR TITLE
fix: torch >= 2.6 compatibility

### DIFF
--- a/libero/libero/benchmark/__init__.py
+++ b/libero/libero/benchmark/__init__.py
@@ -161,7 +161,7 @@ class Benchmark(abc.ABC):
             self.tasks[i].problem_folder,
             self.tasks[i].init_states_file,
         )
-        init_states = torch.load(init_states_path)
+        init_states = torch.load(init_states_path, weights_only=False)
         return init_states
 
     def set_task_embs(self, task_embs):

--- a/libero/lifelong/evaluate.py
+++ b/libero/lifelong/evaluate.py
@@ -251,7 +251,7 @@ def main():
         init_states_path = os.path.join(
             cfg.init_states_folder, task.problem_folder, task.init_states_file
         )
-        init_states = torch.load(init_states_path)
+        init_states = torch.load(init_states_path, weights_only=False)
         indices = np.arange(env_num) % init_states.shape[0]
         init_states_ = init_states[indices]
 

--- a/libero/lifelong/metric.py
+++ b/libero/lifelong/metric.py
@@ -104,7 +104,7 @@ def evaluate_one_task_success(
         init_states_path = os.path.join(
             cfg.init_states_folder, task.problem_folder, task.init_states_file
         )
-        init_states = torch.load(init_states_path)
+        init_states = torch.load(init_states_path, weights_only=False)
         num_success = 0
         for i in range(eval_loop_num):
             env.reset()

--- a/libero/lifelong/utils.py
+++ b/libero/lifelong/utils.py
@@ -56,7 +56,7 @@ def torch_save_model(model, model_path, cfg=None, previous_masks=None):
 
 
 def torch_load_model(model_path, map_location=None):
-    model_dict = torch.load(model_path, map_location=map_location)
+    model_dict = torch.load(model_path, weights_only=False, map_location=map_location)
     cfg = None
     if "cfg" in model_dict:
         cfg = model_dict["cfg"]


### PR DESCRIPTION
This PR fixes LIBERO's compatibility with torch>=2.6 by adding `weights_only=False` to `torch.load`, which is a breaking change in torch 2.6 that denies any other data structures besides tensor, primitives, and dictionary. See https://docs.pytorch.org/docs/stable/notes/serialization.html#weights-only

When running LIBERO on torch 2.6, the following error occurs:
```
File "/opt/libero/libero/libero/benchmark/__init__.py", line 164, in get_task_init_states
    init_states = torch.load(init_states_path)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/openvla/lib/python3.11/site-packages/torch/serialization.py", line 1470, in load
    raise pickle.UnpicklingError(_get_wo_message(str(e))) from None
_pickle.UnpicklingError: Weights only load failed. This file can still be loaded, to do so you have two options, do those steps only if you trust the source of the checkpoint.
    (1) In PyTorch 2.6, we changed the default value of the `weights_only` argument in `torch.load` from `False` to `True`. Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.
    (2) Alternatively, to load with `weights_only=True` please check the recommended steps in the following error message.
    WeightsUnpickler error: Unsupported global: GLOBAL numpy.core.multiarray._reconstruct was not an allowed global by default. Please use `torch.serialization.add_safe_globals([_reconstruct])` or the `torch.serialization.safe_globals([_reconstruct])` context manager to allowlist this global if you trust this class/function.
```

After adding the `weights_only` argument, the states can be correctly loaded and LIBERO can run on torch >= 2.6. Supposedly, this addresses https://github.com/Lifelong-Robot-Learning/LIBERO/issues/99.
